### PR TITLE
🔧 chore(workflow): update cron schedules for workflows

### DIFF
--- a/.github/workflows/ci-check-pr-status.yml
+++ b/.github/workflows/ci-check-pr-status.yml
@@ -102,7 +102,7 @@ jobs:
       RUNNER: ${{ vars.RUNNER }}
       CHECKOUT: ${{ github.ref }}
       VERSION: 'check'
-      LANGUAGE: 'all'
+      LANGUAGE: 'zh_TW'
       LANGUAGE_SOURCE: 'en_US'
       ACTOR_NAME: ${{ vars.ACTOR_NAME }}
       ACTOR_EMAIL: ${{ vars.ACTOR_EMAIL }}
@@ -130,7 +130,7 @@ jobs:
       RUNNER: ${{ vars.RUNNER }}
       CHECKOUT: ${{ github.ref }}
       VERSION: 'rolling'
-      LANGUAGE: 'all'
+      LANGUAGE: 'zh_TW'
       MODE_OF_UPDATE: 'COMPARE'
       BASEURL_HREF: ${{ vars.BASEURL_HREF }}
       SPHINX_BUILDER: 'html'

--- a/.github/workflows/ci-crowdin-download-po.yml
+++ b/.github/workflows/ci-crowdin-download-po.yml
@@ -6,8 +6,8 @@ name: ci-crowdin-download-po
 on:
   # Triggers the workflow based on a schedule.
   schedule:
-    - cron: '0 8 * * 1'   # CRON_dev
-    - cron: '0 0 1 * *'   # CRON_rel
+    - cron: '0 0 * * 1'   # CRON_dev
+    - cron: '0 0 * * 2'   # CRON_rel
   # Triggers the workflow manually through the GitHub UI.
   workflow_dispatch:
     inputs:
@@ -48,8 +48,8 @@ on:
           - 'NEVER'
 
 env:
-  CRON_dev: '0 8 * * 1'
-  CRON_rel: '0 0 1 * *'
+  CRON_dev: '0 0 * * 1'
+  CRON_rel: '0 0 * * 2'
 
 jobs:
   precondition:

--- a/.github/workflows/ci-deploy-po-version.yml
+++ b/.github/workflows/ci-deploy-po-version.yml
@@ -7,7 +7,7 @@ on:
   # Triggers the workflow based on a schedule.
   schedule:
     - cron: '0 8 * * 1'   # CRON_dev
-    - cron: '0 8 1 * *'   # CRON_rel
+    - cron: '0 8 * * 2'   # CRON_rel
   # Triggers the workflow manually through the GitHub UI.
   workflow_dispatch:
     inputs:
@@ -35,7 +35,7 @@ on:
 
 env:
   CRON_dev: '0 8 * * 1'
-  CRON_rel: '0 8 1 * *'
+  CRON_rel: '0 8 * * 2'
 
 jobs:
   precondition:

--- a/.github/workflows/ci-gettext-compendium.yml
+++ b/.github/workflows/ci-gettext-compendium.yml
@@ -7,7 +7,7 @@ on:
   # Triggers the workflow based on a schedule.
   schedule:
     - cron: '0 4 * * 1'   # CRON_dev
-    - cron: '0 4 1 * *'   # CRON_rel
+    - cron: '0 4 * * 2'   # CRON_rel
   # Triggers the workflow manually through the GitHub UI.
   workflow_dispatch:
     inputs:
@@ -40,7 +40,7 @@ on:
 
 env:
   CRON_dev: '0 4 * * 1'
-  CRON_rel: '0 4 1 * *'
+  CRON_rel: '0 4 * * 2'
 
 jobs:
   precondition:

--- a/.github/workflows/ci-gettext-statistics.yml
+++ b/.github/workflows/ci-gettext-statistics.yml
@@ -7,7 +7,7 @@ on:
   # Triggers the workflow based on a schedule.
   schedule:
     - cron: '0 0 * * 1'   # CRON_dev
-    - cron: '0 0 1 * *'   # CRON_rel
+    - cron: '0 0 * * 2'   # CRON_rel
   # Triggers the workflow manually through the GitHub UI.
   workflow_dispatch:
     inputs:
@@ -35,7 +35,7 @@ on:
 
 env:
   CRON_dev: '0 0 * * 1'
-  CRON_rel: '0 0 1 * *'
+  CRON_rel: '0 0 * * 2'
 
 jobs:
   precondition:

--- a/.github/workflows/ci-sphinx-build-docs.yml
+++ b/.github/workflows/ci-sphinx-build-docs.yml
@@ -7,7 +7,7 @@ on:
   # Triggers the workflow based on a schedule.
   schedule:
     - cron: '0 8 * * 1'   # CRON_dev
-    - cron: '0 8 1 * *'   # CRON_rel
+    - cron: '0 8 * * 2'   # CRON_rel
   # Triggers the workflow manually through the GitHub UI.
   workflow_dispatch:
     inputs:
@@ -48,7 +48,7 @@ on:
 
 env:
   CRON_dev: '0 8 * * 1'
-  CRON_rel: '0 8 1 * *'
+  CRON_rel: '0 8 * * 2'
 
 jobs:
   precondition:

--- a/.github/workflows/ci-sphinx-update-pot.yml
+++ b/.github/workflows/ci-sphinx-update-pot.yml
@@ -7,7 +7,7 @@ on:
   # Triggers the workflow based on a schedule.
   schedule:
     - cron: '0 8 * * 1'   # CRON_dev
-    - cron: '0 8 1 * *'   # CRON_rel
+    - cron: '0 8 * * 2'   # CRON_rel
   # Triggers the workflow manually through the GitHub UI.
   workflow_dispatch:
     inputs:
@@ -44,7 +44,7 @@ on:
 
 env:
   CRON_dev: '0 8 * * 1'
-  CRON_rel: '0 8 1 * *'
+  CRON_rel: '0 8 * * 2'
 
 jobs:
   precondition:


### PR DESCRIPTION
- Updated `CRON_rel` schedules to run on Tuesdays instead of the 1st of the month.
- Updated `LANGUAGE` input to 'zh_TW' for ci-check-pr-status.yml workflow.